### PR TITLE
set local variable to fix breaking bug on sorting links

### DIFF
--- a/lib/filterrific/action_view_extension.rb
+++ b/lib/filterrific/action_view_extension.rb
@@ -75,7 +75,7 @@ module Filterrific
       }.merge(opts)
       opts.merge!(
         :html_attrs => opts[:html_attrs].with_indifferent_access,
-        :current_sorting => filterrific.send(opts[:sorting_scope_name]),
+        :current_sorting => (current_sorting = filterrific.send(opts[:sorting_scope_name])),
         :current_sort_key => current_sorting ? current_sorting.gsub(/_asc|_desc/, '') : nil,
         :current_sort_direction => current_sorting ? (current_sorting =~ /_desc\z/ ? 'desc' : 'asc') : nil,
       )

--- a/lib/filterrific/action_view_extension.rb
+++ b/lib/filterrific/action_view_extension.rb
@@ -78,6 +78,7 @@ module Filterrific
         :current_sorting => (current_sorting = filterrific.send(opts[:sorting_scope_name])),
         :current_sort_key => current_sorting ? current_sorting.gsub(/_asc|_desc/, '') : nil,
         :current_sort_direction => current_sorting ? (current_sorting =~ /_desc\z/ ? 'desc' : 'asc') : nil,
+        :current_sort_direction_indicator => (current_sorting =~ /_desc\z/ ? opts[:ascending_indicator] : opts[:descending_indicator]),
       )
       new_sort_key = sort_key.to_s
       if new_sort_key == opts[:current_sort_key]


### PR DESCRIPTION
@jhund I'm trying to upgrade my app from 1.4.x to 2.0, and I'm getting this error:

undefined local variable or method `current_sorting' for <#<Class:0x007fc18f8ea410>:0x007fc18bb7f5f8>

If I remove all of the filterrific_sorting_links or make the change in this pull request the error disappears.

Another problem I'm noticing is that after I make this fix, I don't get the ascending/descending indicators in my links anymore. The arrows were showing up in 1.4 but don't show up in 2.0. Any ideas why that might be happening?