### PR TITLE
fix mistake, direction indicators reversed

### DIFF
--- a/lib/filterrific/action_view_extension.rb
+++ b/lib/filterrific/action_view_extension.rb
@@ -78,7 +78,7 @@ module Filterrific
         :current_sorting => (current_sorting = filterrific.send(opts[:sorting_scope_name])),
         :current_sort_key => current_sorting ? current_sorting.gsub(/_asc|_desc/, '') : nil,
         :current_sort_direction => current_sorting ? (current_sorting =~ /_desc\z/ ? 'desc' : 'asc') : nil,
-        :current_sort_direction_indicator => (current_sorting =~ /_desc\z/ ? opts[:ascending_indicator] : opts[:descending_indicator]),
+        :current_sort_direction_indicator => (current_sorting =~ /_desc\z/ ? opts[:descending_indicator] : opts[:ascending_indicator]),
       )
       new_sort_key = sort_key.to_s
       if new_sort_key == opts[:current_sort_key]


### PR DESCRIPTION
Thank you for merging #44 
This is embarrassing: I reversed the indicators for the current_sort_direction_indicator. This pull will fix that mistake.