### PR TITLE
Fix js event bind error when using turbolinks

### DIFF
--- a/app/assets/javascripts/filterrific/filterrific-jquery.js
+++ b/app/assets/javascripts/filterrific/filterrific-jquery.js
@@ -79,12 +79,12 @@ Filterrific.submitFilterForm = function(){
 
 
 
-// Initialize event observers on document ready
-jQuery(document).ready(function($) {
+// Initialize event observers on document ready and turbolinks page:load
+jQuery(document).on('ready page:load', function() {
   // Add change event handler to all Filterrific filter inputs.
-  $(document).on(
+  $('#filterrific_filter').on(
     "change",
-    "#filterrific_filter :input",
+    ":input",
     Filterrific.submitFilterForm
   );
 


### PR DESCRIPTION
when using filterrific with rails 4 turbolinks, periodic observer will not bind when page change, and if add jquery.turbolinks to hijack document ready, it will lead :input change bind to document repeatedly.