### PR TITLE
Scope with arity 0 and enum requests compatible

### DIFF
--- a/lib/filterrific/active_record_extension.rb
+++ b/lib/filterrific/active_record_extension.rb
@@ -65,11 +65,14 @@ module Filterrific
       # Apply filterrific params
       filterrific_available_filters.each do |filter_name|
         filter_param = filterrific_param_set.send(filter_name)
-        next if filter_param.blank? # skip blank filter_params
-        ar_rel = ar_rel.send(filter_name, filter_param)
-      end
-
-      ar_rel
+          next if filter_param.blank? # skip blank filter_params
+          begin
+            ar_rel = ar_rel.send(filter_name, filter_param)
+          rescue ArgumentError #if we have a scope with arity 0 or enum query, we can perform the request without the parameter
+            ar_rel = ar_rel.send(filter_name) if (filter_param == 1)
+          end
+        end
+        ar_rel
     end
 
   protected


### PR DESCRIPTION
Hello, 

I really wanted to use my enum-styled queries and 0-parameters scope. I've adapted filterriffic in a way to afford that. 
As arity for scope and enums doesn't work as expected I use the ArgumentError exception. 

    filterrific_available_filters.each do |filter_name|
        filter_param = filterrific_param_set.send(filter_name)
          next if filter_param.blank? # skip blank filter_params
          begin
            ar_rel = ar_rel.send(filter_name, filter_param)
          rescue ArgumentError #if we have a scope with arity 0 or enum query, we can perform the request without the parameter
            ar_rel = ar_rel.send(filter_name) if (filter_param == 1)
          end
        end
        ar_rel
    end