### PR TITLE
Don't parse a hypen (-) as an int, also allow 0

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -82,12 +82,12 @@ module Filterrific
           fp[key] = val.call
         when val.is_a?(Array)
           # type cast integers in the array
-          fp[key] = fp[key].map { |e| e =~ /\A[1-9\-]\d*\z/ ? e.to_i : e }
+          fp[key] = fp[key].map { |e| e =~ /\A-?\d+\z/ ? e.to_i : e }
         when val.is_a?(Hash)
           # type cast Hash to OpenStruct so that nested params render correctly
           # in the form
           fp[key] = OpenStruct.new(fp[key])
-        when val =~ /\A[1-9\-]\d*\z/
+        when val =~ /\A-?\d+\z/
           # type cast integer
           fp[key] = fp[key].to_i
         end


### PR DESCRIPTION
Previously a single hyphen would be converted to a zero, rather than being left as the string `'-'`. Also, a zero was not parsed as an int, leaving it as the string `'0'`.
