### PR TITLE
abort previous request before creating a new one

### DIFF
--- a/app/assets/javascripts/filterrific/filterrific-jquery.js
+++ b/app/assets/javascripts/filterrific/filterrific-jquery.js
@@ -23,8 +23,14 @@ Filterrific.submitFilterForm = function(){
       url = form.attr("action");
   // turn on spinner
   $('.filterrific_spinner').show();
+
+  // Abort previous ajax request
+  if (Filterrific.lastRequest && Filterrific.lastRequest.readyState != 4) {
+    Filterrific.lastRequest.abort();
+  }
+
   // Submit ajax request
-  $.ajax({
+  Filterrific.lastRequest = $.ajax({
     url: url,
     data: form.serialize(),
     type: 'GET',


### PR DESCRIPTION
Currently, previous requests are not aborted. When fast typing is combined with heavy search queries it will create a queue of pending concurrent requests which can complete in no chronological order and cause glitches + result in not the last search value result being presented in the end.

This PR resolves the issue by storing latest request and aborting it before starting a new one.