### PR TITLE
Helps to fix #79

### DIFF
--- a/app/assets/javascripts/filterrific/filterrific-jquery.js
+++ b/app/assets/javascripts/filterrific/filterrific-jquery.js
@@ -23,6 +23,9 @@ Filterrific.submitFilterForm = function(){
       url = form.attr("action");
   // turn on spinner
   $('.filterrific_spinner').show();
+  // Trigger a custom event so that others may then bind to it, if they want to.
+  // Example: I want to do something whenever the filtered results changes.
+  $('#filterrific_filter').trigger('filterrific_filter:submit');
   // Submit ajax request
   $.ajax({
     url: url,


### PR DESCRIPTION
@jhund I thought that this might be helpful in resolving #79 in that you (as in the person using the gem, not you personally) can simply add to your code: 

```js
$('body').on('filterrific_filter:submit', null, null, function(e){
  history.pushState(null, '', "?" + $("#filterrific_filter").serialize());
});
```

Thoughts?

I don't want to add the above code itself directly to the gem since this also pollutes the URL and some people may not want that in their app.