### PR TITLE
Add the single license attribute

### DIFF
--- a/filterrific.gemspec
+++ b/filterrific.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.authors = ['Jo Hund']
   gem.email = 'jhund@clearcove.ca'
   gem.homepage = 'http://filterrific.clearcove.ca'
+  gem.license  = 'MIT'
   gem.licenses = ['MIT']
   gem.summary = 'A Rails engine plugin for filtering ActiveRecord lists.'
   gem.description = %(Filterrific is a Rails Engine plugin that makes it easy to filter, search, and sort your ActiveRecord lists.)


### PR DESCRIPTION
Some verifiers don't appear to correctly parse the licenses attribute, so adding the single license version.