### PR TITLE
Update Ruby versions in Travis to be appropriate for Rails 5.1+ and 1/1/2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: ruby
 
 script: "bundle exec rake test"
-
+before_install:
+  - gem update --system
 rvm:
-  - 2.0.0
-  - 2.1.5
-  - 2.2.3
-  - 2.3.1
-  - 2.4.1
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0


### PR DESCRIPTION
Include a workaround for a Travis CI 2.5.0 bug. - run 'gem update --system'