### PR TITLE
Ability to pass custom url parameter instead of default filterrific

### DIFF
--- a/lib/filterrific/action_view_extension.rb
+++ b/lib/filterrific/action_view_extension.rb
@@ -74,6 +74,7 @@ module Filterrific
         :label => sort_key.to_s.humanize,
         :sorting_scope_name => :sorted_by,
         :url_for_attrs => {},
+        :as => :filterrific
       }.merge(opts)
       opts.merge!(
         :html_attrs => opts[:html_attrs].with_indifferent_access,
@@ -110,7 +111,7 @@ module Filterrific
       new_filterrific_params = filterrific.to_hash
                                           .with_indifferent_access
                                           .merge(opts[:sorting_scope_name] => new_sorting)
-      url_for_attrs = opts[:url_for_attrs].merge(:filterrific => new_filterrific_params)
+      url_for_attrs = opts[:url_for_attrs].merge(opts[:as] => new_filterrific_params)
       link_to(
         safe_join([opts[:label], opts[:current_sort_direction_indicator]], ' '),
         url_for(url_for_attrs),
@@ -133,7 +134,7 @@ module Filterrific
       new_filterrific_params = filterrific.to_hash
                                           .with_indifferent_access
                                           .merge(opts[:sorting_scope_name] => new_sorting)
-      url_for_attrs = opts[:url_for_attrs].merge(:filterrific => new_filterrific_params)
+      url_for_attrs = opts[:url_for_attrs].merge(opts[:as] => new_filterrific_params)
       link_to(
         opts[:label],
         url_for(url_for_attrs),


### PR DESCRIPTION
form_for_filterrific has the option :as but if I set it to :filters for example then the sorting links will not work as default is filterrific. This pull request add ability to pass custom url param to the filterrific_sorting_link.