### PR TITLE
Allow filters to be aliased on the controller side

### DIFF
--- a/spec/filterrific/action_controller_extension_spec.rb
+++ b/spec/filterrific/action_controller_extension_spec.rb
@@ -107,6 +107,37 @@ module Filterrific
         ).must_equal({ 'filter1' => 1 })
       end
 
+      it "limits filter params to opts['available_filters'] with aliases" do
+        TestController.new.send(
+          :compute_filterrific_params,
+          TestModelClass,
+          { 'filterX' => 1, 'filter2' => 2 },
+          { 'available_filters' => [{'filter1' => 'filterX'}] },
+          'test_controller#index'
+        ).must_equal({ 'filter1' => 1 })
+      end
+
+      it "limits filter params to opts['available_filters'] with multiple aliases" do
+        TestController.new.send(
+          :compute_filterrific_params,
+          TestModelClass,
+          { 'filterX' => 1, 'filter2' => 2 },
+          { 'available_filters' => [{filter1: :filterX, filter2: :filterY}] },
+          'test_controller#index'
+        ).must_equal({ 'filter1' => 1 , 'filter2' => 2})
+      end
+
+      it "limits filter params to opts['available_filters'] with single alias hash" do
+        TestController.new.send(
+          :compute_filterrific_params,
+          TestModelClass,
+          { 'filterXYZ' => 1, 'filter2' => 2 },
+          # Note:  available filter is in a hash, not an array.
+          { 'available_filters' => {'filter1' => 'filterXYZ'}},
+          'test_controller#index'
+        ).must_equal({ 'filter1' => 1 })
+      end
+
       it "sanitizes filterrific params by default" do
         TestController.new.send(
           :compute_filterrific_params,
@@ -159,5 +190,3 @@ module Filterrific
 
   end
 end
-
-


### PR DESCRIPTION
Available filterrific params can now be aliased on the controller side. This
avoids conventional scope names on the model side with
prefixes (e. g. by_property, for_property) in api parameters.

Example:

available_filters: [
  sorted_by,
  { by_user: :user, by_comment: :comment },
]

filters that are available becomes: by_user, user, by_comment, comment

The filterrific params user and comment will now be renamed to by_user and
by_comment and the api avoids the by_ prefix. The sorted_by filter remains
unchanged.