### PR TITLE
Fix asset precompilation issue

### DIFF
--- a/filterrific.gemspec
+++ b/filterrific.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |gem|
     'MIT-LICENSE',
     'Rakefile',
     'README*',
-    '{app,bin,doc,lib,spec}/**/*'
+    '{app,bin,doc,lib,spec,config}/**/*'
   ]
 end


### PR DESCRIPTION
Why: configuration to include the asset in precompile list is not being loaded as the file is not present in the gem. This works when referencing the gem via path on the local filesystem however.