### PR TITLE
Prepare filterrific to use Minitest 6.0

### DIFF
--- a/spec/filterrific/action_controller_extension_spec.rb
+++ b/spec/filterrific/action_controller_extension_spec.rb
@@ -36,11 +36,11 @@ module Filterrific
     describe '#initialize_filterrific' do
 
       it 'returns a Filterrific::ParamSet' do
-        TestController.new.send(
+        _(TestController.new.send(
           :initialize_filterrific,
           TestModelClass,
           { 'filter1' => 1, 'filter2' => 2 },
-        ).must_be_instance_of(ParamSet)
+        )).must_be_instance_of(ParamSet)
       end
 
     end
@@ -48,9 +48,9 @@ module Filterrific
     describe '#compute_default_persistence_id' do
 
       it 'computes the default persistence id from controller_name and action_name' do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_default_persistence_id
-        ).must_equal('test_controller#index')
+        )).must_equal('test_controller#index')
       end
 
     end
@@ -58,93 +58,93 @@ module Filterrific
     describe '#compute_filterrific_params' do
 
       it 'uses filterrific_params if given' do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           { 'filter1' => 1, 'filter2' => 2 },
           { },
           'test_controller#index'
-        ).must_equal({ 'filter1' => 1, 'filter2' => 2 })
+        )).must_equal({ 'filter1' => 1, 'filter2' => 2 })
       end
 
       it 'uses session if filterrific_params are blank' do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           {},
           { },
           'test_controller#index',
-        ).must_equal({ 'filter1' => '1_from_session', 'filter2' => '2_from_session' })
+        )).must_equal({ 'filter1' => '1_from_session', 'filter2' => '2_from_session' })
       end
 
       it "uses opts['default_filter_params'] if session is blank" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           {},
           { 'default_filter_params' => { 'filter1' => '1_from_opts' } },
           'non existent persistence id to skip session',
-        ).must_equal({ 'filter1' => '1_from_opts' })
+        )).must_equal({ 'filter1' => '1_from_opts' })
       end
 
       it "uses model default_filter_params if opts is blank" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           {},
           { },
           'non existent persistence id to skip session',
-        ).must_equal({ 'filter1' => '1_from_model_defaults' })
+        )).must_equal({ 'filter1' => '1_from_model_defaults' })
       end
 
       it "limits filter params to opts['available_filters']" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
-          TestModelClass,
+          _(TestModelClass),
           { 'filter1' => 1, 'filter2' => 2 },
           { 'available_filters' => %w[filter1] },
           'test_controller#index'
-        ).must_equal({ 'filter1' => 1 })
+        )).must_equal({ 'filter1' => 1 })
       end
 
       it "sanitizes filterrific params by default" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
-          TestModelClass,
+          _(TestModelClass),
           { 'filter1' => "1' <script>alert('xss attack!');</script>" },
           { },
           'test_controller#index'
-        ).must_equal({ 'filter1' => "1' alert('xss attack!');" })
+        )).must_equal({ 'filter1' => "1' alert('xss attack!');" })
       end
 
       it "sanitizes filterrific Array params" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           { 'filter1' => ["1' <script>alert('xss attack!');</script>", 3] },
           { },
           'test_controller#index'
-        ).must_equal({ 'filter1' => ["1' alert('xss attack!');", 3] })
+        )).must_equal({ 'filter1' => ["1' alert('xss attack!');", 3] })
       end
 
       it "sanitizes filterrific Hash params" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           { 'filter1' => { 1 => "1' <script>alert('xss attack!');</script>", 2 =>  3} },
           { },
           'test_controller#index'
-        ).must_equal({ 'filter1' => { 1 => "1' alert('xss attack!');", 2 => 3 } })
+        )).must_equal({ 'filter1' => { 1 => "1' alert('xss attack!');", 2 => 3 } })
       end
 
       it "skips param sanitization if told so via options" do
-        TestController.new.send(
+        _(TestController.new.send(
           :compute_filterrific_params,
           TestModelClass,
           { 'filter1' => "1' <script>alert('xss attack!');</script>" },
           { :sanitize_params => false },
           'test_controller#index'
-        ).must_equal({ 'filter1' => "1' <script>alert('xss attack!');</script>" })
+        )).must_equal({ 'filter1' => "1' <script>alert('xss attack!');</script>" })
       end
 
     end
@@ -152,12 +152,10 @@ module Filterrific
     describe '#reset_filterrific_url' do
 
       it 'responds to #reset_filterrific_url' do
-        TestController.new.must_respond_to(:reset_filterrific_url)
+        _(TestController.new).must_respond_to(:reset_filterrific_url)
       end
 
     end
 
   end
 end
-
-

--- a/spec/filterrific/action_view_extension_spec.rb
+++ b/spec/filterrific/action_view_extension_spec.rb
@@ -10,19 +10,19 @@ module Filterrific
     end
 
     it 'responds to #form_for_filterrific' do
-      ViewContext.new.must_respond_to(:form_for_filterrific)
+      _(ViewContext.new).must_respond_to(:form_for_filterrific)
     end
 
     it 'responds to #render_filterrific_spinner' do
-      ViewContext.new.must_respond_to(:render_filterrific_spinner)
+      _(ViewContext.new).must_respond_to(:render_filterrific_spinner)
     end
 
     it 'responds to #filterrific_sorting_link' do
-      ViewContext.new.must_respond_to(:filterrific_sorting_link)
+      _(ViewContext.new).must_respond_to(:filterrific_sorting_link)
     end
 
     it 'responds to #reset_filterrific_url' do
-      ViewContext.new.must_respond_to(:reset_filterrific_url)
+      _(ViewContext.new).must_respond_to(:reset_filterrific_url)
     end
 
   end

--- a/spec/filterrific/active_record_extension_spec.rb
+++ b/spec/filterrific/active_record_extension_spec.rb
@@ -33,11 +33,11 @@ module Filterrific
     describe "Class method extensions" do
 
       it "adds a 'filterrific' class method" do
-        filterrific_class.must_respond_to(:filterrific)
+        _(filterrific_class).must_respond_to(:filterrific)
       end
 
       it "adds a 'filterrific_find' class method" do
-        filterrific_class.must_respond_to(:filterrific_find)
+        _(filterrific_class).must_respond_to(:filterrific_find)
       end
 
     end
@@ -45,36 +45,36 @@ module Filterrific
     describe "Filterrific initialization" do
 
       it "initializes filterrific_available_filters" do
-        filterrific_class.filterrific_available_filters.must_equal(
+        _(filterrific_class.filterrific_available_filters).must_equal(
           TestDataARES.filterrific_available_filters
         )
       end
 
       it "initializes filterrific_default_filter_params" do
-        filterrific_class.filterrific_default_filter_params.must_equal(
+        _(filterrific_class.filterrific_default_filter_params).must_equal(
           TestDataARES.filterrific_default_filter_params
         )
       end
 
       it "raises when no available_filters are given" do
-        proc {
+        _(proc {
           Class.new(ActiveRecord::Base) do
             filterrific(
               available_filters: []
             )
           end
-        }.must_raise(ArgumentError)
+        }).must_raise(ArgumentError)
       end
 
       it "raises when default_settings contains keys that are not in available_filters" do
-        proc {
+        _(proc {
           Class.new(ActiveRecord::Base) do
             filterrific(
               available_filters: [:one, :two],
               default_filter_params:{ three: '' }
             )
           end
-        }.must_raise(ArgumentError)
+        }).must_raise(ArgumentError)
       end
 
     end
@@ -82,9 +82,9 @@ module Filterrific
     describe "filterrific_find" do
 
       it "raises when given invalid params" do
-        proc {
+        _(proc {
           filterrific_class.filterrific_find('an invalid argument')
-        }.must_raise(ArgumentError)
+        }).must_raise(ArgumentError)
       end
 
     end
@@ -102,11 +102,11 @@ module Filterrific
     end
 
     %w(one two).each do |value|
-      it { Daddy.filterrific_available_filters.must_include value }
+      it { _(Daddy.filterrific_available_filters).must_include value }
     end
 
     %w(three four).each do |value|
-      it { Girl.filterrific_available_filters.must_include value }
+      it { _(Girl.filterrific_available_filters).must_include value }
     end
 
   end

--- a/spec/filterrific/param_set_spec.rb
+++ b/spec/filterrific/param_set_spec.rb
@@ -95,7 +95,7 @@ module Filterrific
     describe "initialization" do
 
       it "assigns resource class" do
-        filterrific_param_set.model_class.must_equal(ModelClass)
+        _(filterrific_param_set.model_class).must_equal(ModelClass)
       end
 
       describe "dynamic filter_name attr_accessors" do
@@ -103,11 +103,11 @@ module Filterrific
         TestData.filterrific_available_filters.each do |filter_name|
 
           it "defines a getter for '#{ filter_name }'" do
-            filterrific_param_set.must_respond_to(filter_name)
+            _(filterrific_param_set).must_respond_to(filter_name)
           end
 
           it "defines a setter for '#{ filter_name }'" do
-            filterrific_param_set.must_respond_to("#{ filter_name }=")
+            _(filterrific_param_set).must_respond_to("#{ filter_name }=")
           end
 
         end
@@ -115,7 +115,7 @@ module Filterrific
         TestData.filterrific_params.keys.each do |key|
 
           it "assigns conditioned param to '#{ key }' attr" do
-            filterrific_param_set.send(key).must_equal(TestData.filterrific_params_after_conditioning[key])
+            _(filterrific_param_set.send(key)).must_equal(TestData.filterrific_params_after_conditioning[key])
           end
 
         end
@@ -126,14 +126,14 @@ module Filterrific
 
     describe 'find' do
       it 'responds to #find' do
-        filterrific_param_set.must_respond_to(:find)
+        _(filterrific_param_set).must_respond_to(:find)
       end
     end
 
     describe "to_hash" do
 
       it "returns all filterrific_params as hash" do
-        filterrific_param_set.to_hash.must_equal(
+        _(filterrific_param_set.to_hash).must_equal(
           TestData.filterrific_params_as_hash
         )
       end
@@ -143,7 +143,7 @@ module Filterrific
     describe "to_json" do
 
       it "returns all filterrific_params as json string" do
-        filterrific_param_set.to_json.must_equal(
+        _(filterrific_param_set.to_json).must_equal(
           TestData.filterrific_params_as_hash.to_json
         )
       end
@@ -152,25 +152,25 @@ module Filterrific
 
     describe "#select_options" do
       it "exists" do
-        filterrific_param_set.select_options.must_equal({})
+        _(filterrific_param_set.select_options).must_equal({})
       end
 
       it "lets you assign a hash" do
         # Make sure it doesn't raise an exception
         filterrific_param_set.select_options = {}
-        1.must_equal(1)
+        _(1).must_equal(1)
       end
 
       it "lets you set a value" do
         # Make sure it doesn't raise an exception
         filterrific_param_set.select_options[:value] = 1
-        1.must_equal(1)
+        _(1).must_equal(1)
       end
 
       it "returns the same value you set" do
         value = rand(1..200)
         filterrific_param_set.select_options[:value] = value
-        filterrific_param_set.select_options[:value].must_equal(value)
+        _(filterrific_param_set.select_options[:value]).must_equal(value)
       end
     end
 
@@ -187,10 +187,10 @@ module Filterrific
         [{ a_string: 'abc' }, { a_string: 'abc' }],
       ].each do |test_params, xpect|
         it "Handles #{ test_params.inspect }" do
-          filterrific_param_set.send(
+          _(filterrific_param_set.send(
             :condition_filterrific_params,
             test_params
-          ).must_equal(xpect)
+          )).must_equal(xpect)
         end
       end
 


### PR DESCRIPTION
Fix warnings in the test suite: 

```
DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:193. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:155. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:161. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:167. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:173. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_raise from /Users/filterrific/active_record_extension_spec.rb:66. Use _(obj).must_raise instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/active_record_extension_spec.rb:54. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_raise from /Users/filterrific/active_record_extension_spec.rb:77. Use _(obj).must_raise instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/active_record_extension_spec.rb:48. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:110. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:106. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:118. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_include from /Users/filterrific/active_record_extension_spec.rb:109. Use _(obj).must_include instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_include from /Users/filterrific/active_record_extension_spec.rb:105. Use _(obj).must_include instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_include from /Users/filterrific/active_record_extension_spec.rb:105. Use _(obj).must_include instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_include from /Users/filterrific/active_record_extension_spec.rb:109. Use _(obj).must_include instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:98. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:146. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_raise from /Users/filterrific/active_record_extension_spec.rb:87. Use _(obj).must_raise instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/active_record_extension_spec.rb:36. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/active_record_extension_spec.rb:40. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/param_set_spec.rb:129. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/action_controller_extension_spec.rb:155. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:53. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/param_set_spec.rb:136. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/action_view_extension_spec.rb:17. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/action_view_extension_spec.rb:25. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/action_view_extension_spec.rb:13. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_respond_to from /Users/filterrific/action_view_extension_spec.rb:21. Use _(obj).must_respond_to instead. This will fail in Minitest 6.
DEPRECATED: global use of must_be_instance_of from /Users/filterrific/action_controller_extension_spec.rb:43. Use _(obj).must_be_instance_of instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:67. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:87. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:97. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:107. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:117. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:137. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:77. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:127. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/filterrific/action_controller_extension_spec.rb:147. Use _(obj).must_equal instead. This will fail in Minitest 6.
```