### PR TITLE
Fix Ruby 2.7 deprecated warning

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -101,7 +101,7 @@ module Filterrific
           # type cast Hash to OpenStruct so that nested params render correctly
           # in the form
           fp[key] = OpenStruct.new(fp[key])
-        when val =~ integer_detector_regex
+        when val.is_a?(String) && val =~ integer_detector_regex
           # type cast integer
           fp[key] = fp[key].to_i
         end


### PR DESCRIPTION
Fix Ruby 2.7 deprecated warning: 
`filterrific/param_set.rb:104: warning: deprecated Object#=~ is called on Integer; it always returns nil`