### PR TITLE
Bump to rails 7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'rails', '~> 5.0'
+gem 'rails', '~> 7.0'
 
 group :development, :test do
   gem 'gem-release'

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ to find out more!
 
 Every commit to Filterrific is automatically tested against the following scenarios:
 
-|Filterrific version | Rails version  | Ruby environments              | Database adapters                  | Build status |
-|--------------------|----------------|--------------------------------|------------------------------------|--------------|
-| 5.x                | Rails 5.x, 6.x | MRI 2.0.0, 2.1.7, 2.2.3, 2.3.1 | mysql2, postgresql                 |[![Build Status](https://travis-ci.org/jhund/filterrific_demo.svg?branch=rails-5.x)](https://travis-ci.org/jhund/filterrific_demo)|
-| 4.x                | Rails 4.x      | MRI 2.0.0, 2.1.7, 2.2.3, 2.3.1 | mysql, mysql2, postgresql, sqlite3 |[![Build Status](https://travis-ci.org/jhund/filterrific_demo.svg?branch=rails-4.x)](https://travis-ci.org/jhund/filterrific_demo)|
-| 3.x                | Rails 3.2      | MRI 2.0.0, 2.1.7               | mysql, mysql2, postgresql, sqlite3 | Not tested|
-| 2.x                | Rails 3.2      | MRI 1.9.3                      | mysql, mysql2, postgresql, sqlite3 | Not tested|
-| 1.x                | < 3.2          | MRI <= 1.9.3                   | mysql, mysql2, postgresql, sqlite3 | Not tested|
+|Filterrific version | Rails version       | Ruby environments              | Database adapters                  | Build status |
+|--------------------|---------------------|--------------------------------|------------------------------------|--------------|
+| 5.x                | Rails 5.x, 6.x, 7.x | MRI 2.0.0, 2.1.7, 2.2.3, 2.3.1 | mysql2, postgresql                 |[![Build Status](https://travis-ci.org/jhund/filterrific_demo.svg?branch=rails-5.x)](https://travis-ci.org/jhund/filterrific_demo)|
+| 4.x                | Rails 4.x           | MRI 2.0.0, 2.1.7, 2.2.3, 2.3.1 | mysql, mysql2, postgresql, sqlite3 |[![Build Status](https://travis-ci.org/jhund/filterrific_demo.svg?branch=rails-4.x)](https://travis-ci.org/jhund/filterrific_demo)|
+| 3.x                | Rails 3.2           | MRI 2.0.0, 2.1.7               | mysql, mysql2, postgresql, sqlite3 | Not tested|
+| 2.x                | Rails 3.2           | MRI 1.9.3                      | mysql, mysql2, postgresql, sqlite3 | Not tested|
+| 1.x                | < 3.2               | MRI <= 1.9.3                   | mysql, mysql2, postgresql, sqlite3 | Not tested|
 
 ### Guidelines for submitting issues
 

--- a/lib/filterrific.rb
+++ b/lib/filterrific.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-if ![5,6].include?(Rails::VERSION::MAJOR)
-  raise "\n\nThis version of Filterrific only works with Rails 5 and 6.\nPlease see the Filterrific README for the correct version of Filterrific to use with your version of Rails!\n\n"
+if ![5,6,7].include?(Rails::VERSION::MAJOR)
+  raise "\n\nThis version of Filterrific only works with Rails 5, 6 and 7.\nPlease see the Filterrific README for the correct version of Filterrific to use with your version of Rails!\n\n"
 end
 
 require 'filterrific/version'


### PR DESCRIPTION
This PR adds Rails 7 to the list of permitted versions. The test suit remains green and preliminary testing in a rails 7 application hasn't surfaced any issues (thus far). 