### PR TITLE
Migrate CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.7", "3.0", "3.1", ruby-head]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        bundler-cache: true # 'bundle install' and cache gems
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run tests
+      run: bundle exec rake test

--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -96,7 +96,9 @@ module Filterrific
           fp[key] = val.call
         when val.is_a?(Array)
           # type cast integers in the array
-          fp[key] = fp[key].map { |e| e =~ integer_detector_regex ? e.to_i : e }
+          fp[key] = fp[key].map do |e|
+            e.is_a?(String) && e =~ integer_detector_regex ? e.to_i : e
+          end
         when val.is_a?(Hash)
           # type cast Hash to OpenStruct so that nested params render correctly
           # in the form
@@ -109,7 +111,7 @@ module Filterrific
       fp
     end
 
-    # Regex to detect if str represents and int
+    # Regex to detect if str represents an int
     def integer_detector_regex
       /\A-?([1-9]\d*|0)\z/
     end


### PR DESCRIPTION
This PR migrates CI to GitHub Actions as Travis CI.org is no longer active.

Given that the Gemfile runs with Rails 7, we're running those Rubies which are compatible with Rails 7 (2.7, 3.0, 3.1, ruby-head).

To get the tests green on ruby-head, I fixed a minor issue in the param_set implementation where the Regexp operator `=~` was being run against integers.  Restricting such comparisons to strings resolves the issue.

Everything runs green on my fork.