### PR TITLE
Fix nested array attributes

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -29,17 +29,11 @@ module Filterrific
       # will be already initialized with the defaults.
       filterrific_params = model_class.filterrific_default_filter_params  if filterrific_params.blank?
       if defined?(ActionController::Parameters) && filterrific_params.is_a?(ActionController::Parameters)
-        permissible_filter_params = []
-        model_class.filterrific_available_filters.each do |p|
-          if filterrific_params[p].is_a?(ActionController::Parameters)
-            permissible_filter_params << { p => filterrific_params[p].keys }
-          elsif filterrific_params[p].is_a?(Array)
-            permissible_filter_params << { p => [] }
-          else
-            permissible_filter_params << p
-          end
-        end
-        filterrific_params = filterrific_params.permit(permissible_filter_params).to_h.stringify_keys
+        filterrific_params = filterrific_params
+          .slice(*model_class.filterrific_available_filters)
+          .permit!
+          .to_h
+          .stringify_keys
       else
         filterrific_params.stringify_keys!
       end

--- a/spec/filterrific/param_set_spec.rb
+++ b/spec/filterrific/param_set_spec.rb
@@ -1,8 +1,9 @@
 require 'spec_helper'
 require 'filterrific/param_set'
 
-module Filterrific
+require 'action_controller/metal/strong_parameters'
 
+module Filterrific
   describe ParamSet do
 
     # Container for test data
@@ -20,6 +21,7 @@ module Filterrific
           filter_proc
           filter_string
           filter_zero
+          filter_nested_params
         ]
       end
 
@@ -39,6 +41,7 @@ module Filterrific
           'filter_proc' => lambda { 1 + 1 },
           'filter_string' => 'forty-two',
           'filter_zero' => '0',
+          'filter_nested_params' => ActionController::Parameters.new(nested: ActionController::Parameters.new(an_array: %w[one two three]))
         }
       end
 
@@ -54,6 +57,7 @@ module Filterrific
           'filter_proc' => 2,
           'filter_string' => 'forty-two',
           'filter_zero' => 0,
+          'filter_nested_params' => ActionController::Parameters.new(nested: ActionController::Parameters.new(an_array: %w[one two three]))
         }
       end
 
@@ -69,6 +73,7 @@ module Filterrific
           'filter_proc' => 2,
           'filter_string' => 'forty-two',
           'filter_zero' => 0,
+          'filter_nested_params' => ActionController::Parameters.new(nested: ActionController::Parameters.new(an_array: %w[one two three]))
         }
       end
 
@@ -122,6 +127,25 @@ module Filterrific
 
       end
 
+    end
+
+    describe "strong parameters" do
+      let(:filterrific_param_set){
+        Kernel::silence_warnings {
+          Filterrific::ParamSet.new(ModelClass, ActionController::Parameters.new(
+            filter_array_string: %w[one two three],
+            filter_nested_params: ActionController::Parameters.new(an_array: %w[one two three])
+          ))
+        }
+      }
+
+      it "returns arrays" do
+        filterrific_param_set.filter_array_string.must_equal(%w[one two three])
+      end
+
+      it "returns nested params" do
+        filterrific_param_set.filter_nested_params.must_equal(OpenStruct.new(an_array: %w[one two three]))
+      end
     end
 
     describe 'find' do


### PR DESCRIPTION
This PR fixes nested array attributes.

Suppose one sends the following parameters as a filter:

```ruby
filter_nested_params: {
  an_array: %w[one two three],
  a_string: "one"
}
```

This currently only permits `a_string`, because `an_array` would need to be permitted using `an_array: []`.

The following works fine though (it's only a problem when nested):

```ruby
filter_array_string: %w[one two three]
```

I would suggest to change the existing code to permit all available filters, independent of how deep they are nested.