### PR TITLE
Update the params_set to work with bool values

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -57,7 +57,7 @@ module Filterrific
       {}.tap { |h|
         model_class.filterrific_available_filters.each do |filter_name|
           param_value = send(filter_name)
-          if param_value.blank?
+          if param_value.blank? && param_value != false
             # do nothing
           elsif param_value.is_a?(Proc)
             # evaluate Proc so it can be serialized
@@ -115,7 +115,7 @@ module Filterrific
       model_class.filterrific_available_filters.each do |filter_name|
         self.class.send(:attr_accessor, filter_name)
         v = fp[filter_name]
-        send("#{filter_name}=", v) if v.present?
+        send("#{filter_name}=", v) if v.present? || v == false
       end
     end
   end

--- a/spec/filterrific/param_set_spec.rb
+++ b/spec/filterrific/param_set_spec.rb
@@ -16,6 +16,7 @@ module Filterrific
         filter_proc
         filter_string
         filter_zero
+        filter_bool
       ]
     end
 
@@ -34,7 +35,8 @@ module Filterrific
         "filter_negative_int" => "-42",
         "filter_proc" => lambda { 1 + 1 },
         "filter_string" => "forty-two",
-        "filter_zero" => "0"
+        "filter_zero" => "0",
+        "filter_bool" => false
       }
     end
 
@@ -49,7 +51,8 @@ module Filterrific
         "filter_negative_int" => -42,
         "filter_proc" => 2,
         "filter_string" => "forty-two",
-        "filter_zero" => 0
+        "filter_zero" => 0,
+        "filter_bool" => false
       }
     end
 
@@ -64,7 +67,8 @@ module Filterrific
         "filter_negative_int" => -42,
         "filter_proc" => 2,
         "filter_string" => "forty-two",
-        "filter_zero" => 0
+        "filter_zero" => 0,
+        "filter_bool" => false
       }
     end
   end


### PR DESCRIPTION
I noticed while working on https://github.com/rubyforgood/human-essentials/pull/3623 that you are are able to pass `true` into filterrific and it will be handled how you expect, however when you pass in `false` as a param it does not make it to the scope because it is filtered out by `.present?` and `.blank?` checks. I updated the param_set to take this into account and updated the spec to test it. 