### PR TITLE
Allow arrays inside nested parameters

### DIFF
--- a/spec/filterrific/param_set_spec.rb
+++ b/spec/filterrific/param_set_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "filterrific/param_set"
+require "support/action_controller"
 
 module Filterrific
   # Container for test data
@@ -174,6 +175,36 @@ module Filterrific
             test_params
           ).must_equal(xpect)
         end
+      end
+    end
+
+    describe "#permitted_param" do
+      it "permits hash keys that contain string values" do
+        filterrific_param_set.send(
+          :permitted_param,
+          "key", "a_string"
+        ).must_equal("key")
+      end
+
+      it "permits hash keys that contain integer values" do
+        filterrific_param_set.send(
+          :permitted_param,
+          "key", 1
+        ).must_equal("key")
+      end
+
+      it "permits hash keys that contains array values, returning the hash key itself and an empty array" do
+        filterrific_param_set.send(
+          :permitted_param,
+          "key", ["whatever", "values"]
+        ).must_equal({"key" => []})
+      end
+
+      it "permits nested ActionController::Parameters, handling array, scalar values, and other ActionController::Parameters" do
+        filterrific_param_set.send(
+          :permitted_param,
+          "key", ActionController::Parameters.new({"a" => 1, "b" => "2", "c" => ["a", "b"], "d" => ActionController::Parameters.new({"a" => 1, "b" => 2})})
+        ).must_equal({"key" => ["a", "b", {"c" => []}, {"d" => ["a", "b"]}]})
       end
     end
   end

--- a/spec/support/action_controller.rb
+++ b/spec/support/action_controller.rb
@@ -1,0 +1,33 @@
+# Simulate ActionController::Parameters so that we can test the behavior of
+# the gem with Rails.
+module ActionController
+  class Parameters
+    def initialize(hash = {})
+      self.unsafe_hash = hash
+    end
+
+    def [](key)
+      unsafe_hash[key]
+    end
+
+    def []=(key, value)
+      unsafe_hash[key] = value
+    end
+
+    def each(&block)
+      unsafe_hash.each(&block)
+    end
+
+    def to_unsafe_h
+      unsafe_hash
+    end
+
+    def permit(*)
+      self
+    end
+
+    private
+
+    attr_accessor :unsafe_hash
+  end
+end


### PR DESCRIPTION
When one scope is handled by multiple fields, we need to add each of those fields to the permitted params. However, when one of those inner fields includes multiple-select fields, we don't instruct Strong Parameters that those params expect arrays. As a result, those keys are dropped.

This commit fixes that, recursively handling each nested param, so that arrays and other nested fields are supported.

Fixes #225 