### PR TITLE
Expand CHANGELOG entry for 5.2.4 (jquery removal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Filterrific major versions match the Ruby on Rails major versions they work with
 
 ## [5.2.4] - Jan 30, 2023
 
-* Remove JS dependency on jquery
+* Remove JS dependency on jquery (when updating replace `//= require filterrific/filterrific-jquery` by `//= require filterrific/filterrific` in application.js)
 * Make code compliant with standard.rb rules
 
 ## [5.2.3] - Mar. 18, 2022


### PR DESCRIPTION
The documentation (http://filterrific.clearcove.ca/pages/action_view_api.html section application.js) should also be updated.

Thanks a lot for this gem - have been using it for a loong time. And thanks for updating it!