### PR TITLE
Explicitly require OpenStruct in cases where it is not already loaded

### DIFF
--- a/lib/filterrific/param_set.rb
+++ b/lib/filterrific/param_set.rb
@@ -1,5 +1,6 @@
 require "active_support/all"
 require "digest/sha1"
+require "ostruct"
 
 module Filterrific
   # FilterParamSet is a container to store FilterParams


### PR DESCRIPTION
In specific scenarios it is possible that the OpenStruct library is not loaded, leading to an exception being raised by `Filterrific::ParamSet`. `OpenStruct` is used twice in `#to_hash` and the protected `#condition_filterrific_params` methods. Most applications probably already load it, so requiring it again shouldn't cause issues for them. For the niche cases where it's not loaded, requiring it will fix the issue and maintain the existing functionality.