### PR TITLE
Prevent loop running when filterrificForm is null

### DIFF
--- a/app/assets/javascripts/filterrific/filterrific.js
+++ b/app/assets/javascripts/filterrific/filterrific.js
@@ -153,9 +153,11 @@ Filterrific.observe_field = function(inputs_selector, frequency, callback) {
 Filterrific.init = function() {
   // Add change event handler to all Filterrific filter inputs.
   var filterrificForm = document.querySelector('#filterrific_filter');
-  filterrificForm.querySelectorAll('input, textarea, select, textarea').forEach(input => {
-    input.addEventListener('change', Filterrific.submitFilterForm)
-  })
+  if (filterrificForm) {
+    filterrificForm.querySelectorAll('input, textarea, select, textarea').forEach(input => {
+      input.addEventListener('change', Filterrific.submitFilterForm)
+    })
+  }
 
   // Add periodic observer to selected inputs.
   // Use this for text fields you want to observe for change, e.g., a search input.


### PR DESCRIPTION
When there is no filters on a page this error can appear in the console.
I think putting an if statement around it should do?

```
filterrificForm.querySelectorAll('input, textarea, select').forEach(input => {
    input.addEventListener('change', Filterrific.submitFilterForm);
  });
```

![image](https://github.com/user-attachments/assets/99e54b8f-d11f-476a-a894-a8d9e00e2cab)
